### PR TITLE
fix: no need for authentication with login and register

### DIFF
--- a/backend/src/main/java/com/example/todo/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/example/todo/config/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.todo.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -19,7 +20,7 @@ public class WebSecurityConfig {
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   /**
-   * 認証を無視するURLを設定.
+   * セキュリティフィルターチェーンを設定.
    *
    * @param http HttpSecurityオブジェクト
    * @return SecurityFilterChainオブジェクト
@@ -30,7 +31,9 @@ public class WebSecurityConfig {
     http.csrf(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/register", "/login")
+                auth.requestMatchers(HttpMethod.OPTIONS, "/**") // allow preflight requests
+                    .permitAll()
+                    .requestMatchers("/register", "/login")
                     .permitAll()
                     .anyRequest()
                     .authenticated())

--- a/backend/src/main/java/com/example/todo/controller/UserController.java
+++ b/backend/src/main/java/com/example/todo/controller/UserController.java
@@ -73,7 +73,7 @@ public class UserController {
       String token = userService.login(request);
       return ResponseEntity.ok(token);
     } catch (IllegalArgumentException e) {
-      return ResponseEntity.badRequest().body(e.getMessage());
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
   }
 }

--- a/backend/src/main/java/com/example/todo/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/todo/filter/JwtAuthenticationFilter.java
@@ -39,14 +39,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       @NonNull HttpServletResponse response,
       @NonNull FilterChain filterChain)
       throws ServletException, IOException {
-
-    // login, registerの場合は認証フィルターを通さないようにする
-    String path = request.getServletPath();
-    if (path.equals("/login") || path.equals("/register")) {
-      filterChain.doFilter(request, response);
-      return;
-    }
-
     final String authHeader = request.getHeader("Authorization");
     if (authHeader == null || !authHeader.startsWith("Bearer ")) {
       filterChain.doFilter(request, response);


### PR DESCRIPTION
## やったこと
<!-- このPRに関連するissue-->
<!-- PRとともに、issueを閉じたい場合は"close #{issue番号}"で閉じることが可能 -->
#47 
<!-- このPR内でやったことを記載 -->
- /login, /registerの場合のみ認証不要に設定を変更
- preflightによるリクエストも認証不要に

## レビュー情報
<!-- このPR内で特にレビューしてほしいところ、レビューをする上で参考になる情報 -->
- 
